### PR TITLE
Don't check the tuner on every CreateVO

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1046,7 +1046,7 @@ def CreateVO(tuneridx, url, title, year=None, tagline='', summary='', thumb=None
     localIP = tuner.get('LocalIP','')
 
     #If tuner is not available:
-    if CheckTunerAvail(localIP)==0 and include_container:
+    if include_container  and CheckTunerAvail(localIP)==0:
         errmsg='Warning: Tuner not available!\n'
         summary=errmsg + xstr(summary)
     


### PR DESCRIPTION
Checking the tuner on every CreateVO is really expensive and slow.  With
a lot of cable channels the Plex channel will time out.  We should only
be checking if the tuner is alive if include_container is true.