### PR TITLE
Small fix to restore tunercheck for older firmware

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -12,9 +12,9 @@ from lxml import etree
 from DumbTools import DumbPrefs
 
 DEBUGMODE            = True
-TITLE                = 'HDHR Viewer 2 (1.1.4)'
+TITLE                = 'HDHR Viewer 2 (1.1.5)'
 PREFIX               = '/video/hdhrv2'
-VERSION              = '1.1.4'
+VERSION              = '1.1.5'
 
 #GRAPHICS
 ART                  = 'art-default.jpg'
@@ -829,7 +829,7 @@ def GetVcoIcon(channel,program):
 def CheckTunerAvail(ip):
     try:
         htmlData = urllib2.urlopen(URL_HDHR_TUNER_STATUS.format(ip=ip),timeout=TIMEOUT_LAN).read()
-        tuner_avail = re.findall('>not in use<',htmlData)
+        tuner_avail = re.findall('>none<|>not in use<',htmlData)
         return len(tuner_avail)
     except Exception as inst:
         logError('CheckTunerAvail(ip):'+strError(inst))


### PR DESCRIPTION
this should reflect this post https://forums.plex.tv/t/rel-hdhomerun-viewer/59998/1971
It looks like that not all hdhomerun devices get autoupdates